### PR TITLE
Update 02_Boot_Protocols.md - GDT.md link was broken

### DIFF
--- a/01_Build_Process/02_Boot_Protocols.md
+++ b/01_Build_Process/02_Boot_Protocols.md
@@ -60,7 +60,7 @@ If unfamiliar with paging, there is a chapter that goes into more detail in the 
 
 Since we have enabled paging, we'll also need to populate `cr3` with a valid paging structure. This needs to be done before setting the PG bit. Generally these initial page tables can be set up using 2mb pages with the present and writable flags set. Nothing else is needed for the initial pages.
 
-We will be operating in compatibility mode, a subset of long mode that pretends to be a protected mode cpu. This is to allow legacy programs to run in long mode. However we can enter full 64-bit long mode by reloading the CS register with a far jump or far return. See the [GDT notes](../GDT.md) for details on doing that.
+We will be operating in compatibility mode, a subset of long mode that pretends to be a protected mode cpu. This is to allow legacy programs to run in long mode. However we can enter full 64-bit long mode by reloading the CS register with a far jump or far return. See the [GDT notes](../02_Architecture/04_GDT.md) for details on doing that.
 
 It's worth noting that this boot shim will need its own linker sections for code and data, since until we have entered long mode the higher half sections used by the rest of the kernel won't be available, as we have no memory at those addresses yet.
 


### PR DESCRIPTION
I noticed the GDT.md link was broken in 02_Boot_Protocols.md.
Updated it to what I think was the intended link.