### PR TITLE
Fix RSDPDescriptor Mistake

### DIFF
--- a/02_Architecture/06_ACPITables.md
+++ b/02_Architecture/06_ACPITables.md
@@ -46,7 +46,7 @@ struct RSDPDescriptor {
 
 Where the fields are:
 
-* *Signature*: Is an 8 byte string, that must contain: "RSDT PTR " **P.S. The string is not null terminated**
+* *Signature*: Is an 8 byte string, that must contain: "RSD PTR " **P.S. The string is not null terminated**
 * *Checksum*: The value to add to all the other bytes (of the Version 1.0 table) to calculate the Checksum of the table. If this value added to all the others and casted to byte isn't equal to 0, the table must be ignored.
 * *OEMID*: Is a string that identifies the OEM
 * *Revision*: Is the revision number

--- a/99_Appendices/I_Acknowledgments.md
+++ b/99_Appendices/I_Acknowledgments.md
@@ -14,5 +14,5 @@ In no particular order:
 - @seekbytes ([https://github.com/seekbytes](https://github.com/seekbytes))
 - @Flukas88 ([https://github.com/Flukas88](https://github.com/Flukas88))
 - @Rubo3 ([https://github.com/Rubo3](https://github.com/Rubo3))
-- @maxtyson123 ([https://github.com/Rubo3](https://github.com/maxtyson123))
+- @maxtyson123 ([https://github.com/maxtyson123](https://github.com/maxtyson123))
 

--- a/99_Appendices/I_Acknowledgments.md
+++ b/99_Appendices/I_Acknowledgments.md
@@ -14,4 +14,5 @@ In no particular order:
 - @seekbytes ([https://github.com/seekbytes](https://github.com/seekbytes))
 - @Flukas88 ([https://github.com/Flukas88](https://github.com/Flukas88))
 - @Rubo3 ([https://github.com/Rubo3](https://github.com/Rubo3))
+- @maxtyson123 ([https://github.com/Rubo3](https://github.com/maxtyson123))
 


### PR DESCRIPTION
I notice that you say:
• Signature: Is an 8 byte string, that must contain: “RSDT PTR” P.S. The string is not null
terminated

Where it should be “RSD PTR "
[Ref: OSDev Wiki](https://wiki.osdev.org/RSDP#:~:text=This%208%2Dbyte%20string%20(not%20null%20terminated!)%20must%20contain%20%22RSD%20PTR%20%22.%20It%20stands%20on%20a%2016%2Dbyte%20boundary.)

![image](https://github.com/dreamportdev/Osdev-Notes/assets/63089527/41cffd35-33c8-4d07-8580-cbc37d3cc443)
