### PR TITLE
Change "xorisso" typos to "xorriso"

### DIFF
--- a/01_Build_Process/01_Overview.md
+++ b/01_Build_Process/01_Overview.md
@@ -162,7 +162,7 @@ There are other make-like tools out there (xmake, nmake) but these are less popu
 
 There are more details to this, however most bootloaders will provide a tool that lets us create a bootable iso, with the kernel, the bootloader itself and any other files we might want. For grub this is `grub-mkrescue` and limine provides `limine-install` for version 2.x or `limine-deploy` for version 3.x.
 
-While the process of generating an iso is straightforward enough when using something like xorisso, the process of installing a bootloader into that iso is usually bootloader dependent. This is covered more in detail in its own chapter.
+While the process of generating an iso is straightforward enough when using something like xorriso, the process of installing a bootloader into that iso is usually bootloader dependent. This is covered more in detail in its own chapter.
 
 If just here for a quick reference, grub uses `grub-mkrescue` and a `grub.cfg` file, limine reqiures us to build the iso by yourselves with a `limine.cfg` on it, and then run `limine-deploy`.
 

--- a/01_Build_Process/05_Generating_Iso.md
+++ b/01_Build_Process/05_Generating_Iso.md
@@ -5,9 +5,9 @@ The generated iso can then be used as a cdrom in an emulator, or burnt to a real
 
 ## Xorriso
 
-Xorisso is a tool used to create iso disk images. Iso is actually quite a complex format, as it aims to be compatible with a lot of different formats and ways of booting.
+Xorriso is a tool used to create iso disk images. Iso is actually quite a complex format, as it aims to be compatible with a lot of different formats and ways of booting.
 
-A walkthrough of xorisso is outside the scope of this chapter, but just know it's the standard tool for working with the iso format.
+A walkthrough of xorriso is outside the scope of this chapter, but just know it's the standard tool for working with the iso format.
 
 ## Grub (Multiboot 2)
 
@@ -51,10 +51,10 @@ To get started we'll want to create a working directory to use as the root of ou
 
 Now we can copy our `limine.cfg` and kernel into the working directory. The `limine.cfg` file needs to be in one of a few locations in order to be found, the best place is the root directory.
 
-Now we're ready to run the following xorisso command:
+Now we're ready to run the following xorriso command:
 
 ```sh
-xorisso -as mkisofs -b limine-cd.bin -no-emul-boot \
+xorriso -as mkisofs -b limine-cd.bin -no-emul-boot \
     -boot-load-size 4 -boot-info-table --efi-boot \
     limine-cd-efi.bin -efi-boot-part --efi-boot-image \
     --protective-msdos-label disk -o my_iso.iso

--- a/99_Appendices/H_Useful_Resources.md
+++ b/99_Appendices/H_Useful_Resources.md
@@ -10,7 +10,7 @@ This appendix is a collection of links we found useful developing our own kernel
 - Stivale 2 Specification: [https://github.com/stivale/stivale/blob/master/STIVALE2.md](https://github.com/stivale/stivale/blob/master/STIVALE2.md)
 - Stivale 2 Barebones: [https://github.com/stivale/stivale2-barebones/](https://github.com/stivale/stivale2-barebones/)
 - Sabaton - ARM Stivale 2 Bootloader: [https://github.com/FlorenceOS/Sabaton](https://github.com/FlorenceOS/Sabaton)
-- Xorisso Documentation: [https://linux.die.net/man/1/xorriso](https://linux.die.net/man/1/xorriso)
+- Xorriso Documentation: [https://linux.die.net/man/1/xorriso](https://linux.die.net/man/1/xorriso)
 - GNU Make Documenation: [https://www.gnu.org/software/make/manual/make.html](https://www.gnu.org/software/make/manual/make.html)
 - Linker Scripts Documentation : [https://sourceware.org/binutils/docs/ld/Scripts.html#Scripts](https://sourceware.org/binutils/docs/ld/Scripts.html#Scripts)
 - Bootlin Toolchains : [https://toolchains.bootlin.com/](https://toolchains.bootlin.com/)


### PR DESCRIPTION
- Updated instances of "xorisso" to "xorriso"
- "xorriso" is the correct spelling for the ISO 9660 filesystem manipulation tool.