### PR TITLE
Fix typos in Memory Management chapter

### DIFF
--- a/04_Memory_Management/01_Overview.md
+++ b/04_Memory_Management/01_Overview.md
@@ -43,11 +43,11 @@ Usually this is the lowest level of allocation, and only the kernel should acces
 
 ## Paging
 
-Although Paging and VMM are strongly tied, let's split this topic into two parts: with paging we refer to the hardware paging mechanism, that usually involeves tables, and registers and address translation, while the VMM it refers to the higher level (usually architecture independant).
+Although Paging and VMM are strongly tied, let's split this topic into two parts: with paging we refer to the hardware paging mechanism, that usually involves tables, and registers and address translation, while the VMM it refers to the higher level (usually architecture independent).
 
 While writing the support for paging, independently there are few future choices we need to think about now:
 
-* Are we going to have a single or mulitple address spaces (i.e. every task will have its own address space)? If yes in this case we need to keep in mind that when mapping addresses we need to make sure they are done on the right Virtual Memory Space. So usually a good idea is to add an extra parameter to the mapping/unmapping functions that contains the pointer to the root page table (for _x86\_64 architecture is the PML4 table).
+* Are we going to have a single or multiple address spaces (i.e. every task will have its own address space)? If yes in this case we need to keep in mind that when mapping addresses we need to make sure they are done on the right Virtual Memory Space. So usually a good idea is to add an extra parameter to the mapping/unmapping functions that contains the pointer to the root page table (for _x86\_64 architecture is the PML4 table).
 * Are we going to support User and Supervisor mode? In this case we need to make sure that the correct flag is set in the table entries.
 
 ## VMM - Virtual Memory Manager
@@ -71,7 +71,7 @@ Similarly to paging there are some things we need to consider depending on our f
 
 ## Heap Allocator
 
-There is a disntiction to be made here, between the kernel heap and the program heap. Many characteristic are similar between each other, although different algorithm can be used.
+There is a distinction to be made here, between the kernel heap and the program heap. Many characteristic are similar between each other, although different algorithm can be used.
 Usually there is just one kernel heap, while every program will have its own userspace heap.
 
 - At least one per process/running program, and one for the kernel.
@@ -99,7 +99,7 @@ char *a = alloc(5);
 What happens under the hood?
 
 1. The alloc request the heap for pointer to an area of 5 bytes.
-2. The heap allocator searches for a region big enough for 5 bytes, if available in the current heap. If so, no need to dig down further, just return what was found. However if the current heap doesn't contain an area of 5 bytes that can be returned, it will need to expand. So it asks for more space from the VMM. Remember: the *addresses returned by the heap are all virtual*.
+2. The heap allocator searches for a region big enough for 5 bytes, if available in the current heap. If so, no need to dig down further, just return what was found. However, if the current heap doesn't contain an area of 5 bytes that can be returned, it will need to expand. So it asks for more space from the VMM. Remember: the *addresses returned by the heap are all virtual*.
 3. The VMM will allocate a region of virtual memory big enough for the new heap expansion. It then asks the physical memory manager for a new physical page to map there.
 4. Lastly a new physical page from the PMM will be mapped to the VMM (using paging for example). Now the VMM will provide the heap with the extra space it needed, and the heap can return an address using this new space.
 

--- a/04_Memory_Management/02_Physical_Memory.md
+++ b/04_Memory_Management/02_Physical_Memory.md
@@ -34,23 +34,23 @@ So marking a memory location as free or used is just matter of setting clearing 
 
 ### Returning An Address
 
-But how do we mark a page as taken or free? We need to translate row/column in an address, or the address in row/column. Let's assume that we asked fro a free page and we found the first available bit at row 0 and column 3, how we translate it to address, well for that we need few extra info: 
+But how do we mark a page as taken or free? We need to translate row/column in an address, or the address in row/column. Let's assume that we asked for a free page and we found the first available bit at row 0 and column 3, how we translate it to an address, well for that we need a few extra infos: 
 
-* The page size (we should know what is the size of the page we are using), Let's call it `PAGE_SIZE`
-* How many bits are in a row (it's up to us to decide it, in this example we are using an unsigned char, but most probably in real life it is going to be a `uint32_t` for 32bit OS or `uint64_t` for 64bit os) let's call it `BITS_PER_ROW`
+* The page size (we should know what the size of the page we are using is), Let's call it `PAGE_SIZE`
+* How many bits are in a row (it's up to us to decide it, in this example we are using an unsigned char, but most probably in real life it is going to be a `uint32_t` for 32bit OS or `uint64_t` for 64bit OS) let's call it `BITS_PER_ROW`
 
 To get the address we just need to do: 
 
 * `bit_number = (row * BITS_PER_ROW) + column`
 * `address = bit_number * PAGE_SIZE`
 
-Let's pause for a second, and have a look at `bit_number`, what it represent? Maybe it is not straightforward what it is, but consider that the memory is just a linear space of consecutive addresses (just like a long tape of bits grouped in bytes), so when we declare an array we just reserve *NxSizeof(chosendatatype)* contiguous addresses of this space, so the reality is that our array is just something like: 
+Let's pause for a second, and have a look at `bit_number`, what it does it represent? Maybe it is not straightforward what it is, but consider that the memory is just a linear space of consecutive addresses (just like a long tape of bits grouped in bytes), so when we declare an array we just reserve *NxSizeof(chosendatatype)* contiguous addresses of this space, so the reality is that our array is just something like: 
 
  | bit_number | 0 | 1 | 2 | ... | *8* | ... | 31 | *32* | ... | 63 |
  |------------|---|---|---|-----|-----|-----|----|------|-----|----|
  | \*bitmap   | 1 | 1 | 1 | ... | *0* | ... |  0 |  *0* | ... |  0 |
   
-It just represent the offset in bit from `&bitmap` (the starting address of the bitmap). 
+It just represents the offset in bit from `&bitmap` (the starting address of the bitmap). 
 
 In our example with *row=0 column=3* (and page size of 4k) we get:
 
@@ -66,7 +66,7 @@ But what about the opposite way? Given an address compute the bitmap location? S
 
 $$bitmap_{location}=\frac{address}{4096}$$
 
-In this way we know the "page" index into an hypoteteical array of Pages. But we need row and columns, how do we compute them? That depends on the variable size used for the bitmap, let's stick to 8 bits, in this case:
+In this way we know the "page" index into a hypothetical array of Pages. But we need row and columns, how do we compute them? That depends on the variable size used for the bitmap, let's stick to 8 bits, in this case:
 
 * The row is given by `bitmap_location / 8`
 * The column is given by: `bitmap_location % 8`

--- a/04_Memory_Management/03_Paging.md
+++ b/04_Memory_Management/03_Paging.md
@@ -2,7 +2,7 @@
 
 ## What is Paging?
 
-Paging is a memory management scheme that introduces the concept of **_logical addresses_** (virtual address) and **_virtual memory_**. On x86_\* architectures this is achieved via hardware. Paging enables a layer of translation between virtual and physical addresses, and virtual and physical address spaces, as well as adding a few extra features (like access protection, priviledge level protection).
+Paging is a memory management scheme that introduces the concept of **_logical addresses_** (virtual address) and **_virtual memory_**. On x86_\* architectures this is achieved via hardware. Paging enables a layer of translation between virtual and physical addresses, and virtual and physical address spaces, as well as adding a few extra features (like access protection, privilege level protection).
 
 It introduces a few new concepts that are explained below.
 
@@ -18,7 +18,7 @@ These are the basic blocks of paging. Depending on the architecture (and request
 
 What are those directories and tables? Let's start from the tables:
 
-* **Page Table** contains the information about a single page of memory, an entry in a page table represents the starting physical memory addresss for this page.
+* **Page Table** contains the information about a single page of memory, an entry in a page table represents the starting physical memory address for this page.
 * **Page Directory** an entry in a page directory can point to depending on the page size selected:
     - another page directory
     - a page table
@@ -33,7 +33,7 @@ Sometimes CR3 (although technically it's just the data from bits 12+) is referre
 
 ### Virtual (or Logical) Address
 
-A virtual address is what a running program sees. Thats any program: a driver, user application or the kernel itself.
+A virtual address is what a running program sees. That's any program: a driver, user application or the kernel itself.
 
 Sometime in the kernel, a virtual address will map to the same physical address, this scenario it is called `identity mapping`, but this is not always the case though, we can also have the same physical address that maps to different virtual addresses.
 
@@ -41,16 +41,16 @@ A virtual address is usually a composition of entry numbers for each level of ta
 
 ![Address Translation](/Images/addrtranslation.png)
 
-The _memory page_ in the picture refers to a physical memory page (the picture above doesn't refer to any existing hardware paging, is just an example scenario). Using logical address and paging, we can introduce a whole new address space that can be much bigger of the available physical memory.
+The _memory page_ in the picture refers to a physical memory page (the picture above doesn't refer to any existing hardware paging, it is just an example scenario). Using logical addresses and paging, we can introduce a whole new address space that can be much bigger than the available physical memory.
 
 
-For example we can have that:
+For example, we can have that:
 
 ```c
 phys(0x123'456) = virt(0xFFF'F234'5235)
 ```
 
-Meaning that the virtual address `0xFFFF2345235` refers to the phyisical address `0x123456`.
+Meaning that the virtual address `0xFFFF2345235` refers to the physical address `0x123456`.
 
 This mapping is usually achieved through the usage of several hierarchical tables, with each item in one level pointing to the next level table. As already mentioned above a virtual address is a composition of _entry numbers_ for each level of the tables. Now let's assume for example that we have 3 levels paging, 32 bits addressing and the address translation mechanism used is the one in the picture above, and we have the virtual address below:
 
@@ -77,7 +77,7 @@ The above example is just an imaginary translation mechanism, we'll discuss the 
 ## Paging in Long Mode
 
 In 64 bit mode we have up to 4 levels of page tables. The number depends on the size we want to assign to each page.
-It's worth noting that newer cpus do support a feature called _la57_ (large addressing using 57-bits), this just adds another layer of page tables on top the existing 4 to allow for a larger address space. It's a cool feature, but not really required unless we're using crazy amounts of memory.
+It's worth noting that newer CPUs do support a feature called _la57_ (large addressing using 57-bits), this just adds another layer of page tables on top the existing 4 to allow for a larger address space. It's a cool feature, but not really required unless we're using crazy amounts of memory.
 
 There are 3 possible scenarios:
 
@@ -85,7 +85,7 @@ There are 3 possible scenarios:
 * 2Mib Pages: in this case we only need 3 page levels.
 * 1Gib Pages: Only 2 levels are needed.
 
-To implement paging, is strongly reccomended to have already implemented interrupts too, specifically handling #PF (vector 0xd).
+To implement paging, is strongly recommended to have already implemented interrupts too, specifically handling #PF (vector 0xd).
 
 The 4 levels of page directories/tables are:
 
@@ -106,13 +106,13 @@ But before proceeding with the details let's see some of the characteristics com
 * The size of all table type is fixed and is 4k.
 * Every table has exactly 512 entries.
 * Every entry has the size of 64 bits.
-* The tables have a hierarchy, and every item in a table higher in the hierachy point to a lower hierachy one (with some exceptions explained later). The page table points to a memory area.
+* The tables have a hierarchy, and every item in a table higher in the hierarchy point to a lower hierarchy one (with some exceptions explained later). The page table points to a memory area.
 
 The hierarchy of the tables is:
 
 * PML4 is the root table (this is the one that is contained in the PDBR register) and is loaded for the actual address translation (see the next paragraph). Each of its entries point a PDPR table.
 * PDPR, the next level down. Each entry points to a single page directory.
-* Page directory (PD): depending of the value of the PS bit (page size) an entry in this table can point to:
+* Page directory (PD): depending on the value of the PS bit (page size) an entry in this table can point to:
    * a page table if the PS bit is clear (this means we are using 4k pages)
    * 2 MB memory area if the PS bit is set
 * Page table (PT): every entry in the page table points to a 4k memory page.
@@ -123,7 +123,7 @@ In the following paragraphs we will have a look with more detail at how the pagi
 
 ### Loading the root table and enable paging
 
-Until now we have explained how address translation works now let's see how the Root Table is loaded (in `x86_64` is PML4), this is done by loading the special register `CR3`, also known as `PDBR`, we introduced it at the beginning of the chapter, and is contents is basically the base address of our PML4 table. This can be easily done with two lines of assembly:
+Until now, we have explained how address translation works now let's see how the Root Table is loaded (in `x86_64` is PML4), this is done by loading the special register `CR3`, also known as `PDBR`, we introduced it at the beginning of the chapter, and is content is basically the base address of our PML4 table. This can be easily done with two lines of assembly:
 
 ```x86asm
    mov eax, PML4_BASE_ADDRESS
@@ -193,20 +193,20 @@ In the next section we will go through the fields of an entry.
 
 Below is a list of all the fields present in the table entries, with an explanation of the most commonly used.
 
-* **P** (Present): If set this tells the CPU that this entry is valid, and can be used for translation. Otherwise translation stops here, and results in a page fault.
-* **R/W** (Read/Write): Pages are always readable, setting this flag allows writing to memory via this virtual address. Otherwise an attempt to write to memory while this bit is cleared results in a page fault. Reminder that these bits also affect the child tables. So if a pml4 entry is marked as read-only, any address that gets translated through that will be read only, even if the entries in the tables below it have this bit set.
+* **P** (Present): If set this tells the CPU that this entry is valid, and can be used for translation. Otherwise, translation stops here, and results in a page fault.
+* **R/W** (Read/Write): Pages are always readable, setting this flag allows writing to memory via this virtual address. Otherwise, an attempt to write to memory while this bit is cleared results in a page fault. Reminder that these bits also affect the child tables. So if a pml4 entry is marked as read-only, any address that gets translated through that will be read only, even if the entries in the tables below it have this bit set.
 * **User/Supervisor**: It describes the privilege level required to access this address. If clear the page has the supervisor level, while if it is set the level is user. The cpu identifies supervisor/user level by checking the CPL (current protection level, set by the segment registers). If it is less than 3 then the accesses are made in supervisor mode, if it's equal to 3 they are made in user mode.
 * **PWT** (Page Level Write Through): Controls the caching policy (write-through or write-back). I usually leave it to 0, for more information refer to the Intel Developer Manuals.
 * **PCD** (Page Level Cache Disable): Controls the caching of individual pages or tables. I usually leave it to 0, for more information refer to the Intel Developer Manuals.
 * **A** (Accessed): This value is set by the CPU, if is 0 it means the page hasn't been accessed yet. It's set when the page (or page teble) has been accessed since this bit was last cleared.
-* **D** (Dirty): If set, indicates that a page has been written to since last cleared. This flag is supposed to only apply to page tables, but some emulators will set it on other levels as well. This flag and the accessed flag are provided for being use by the memory management software, the CPU only set it when its value is 0. Otherwise is up to the operating system's memory manager to decide if it has to be cleared or not. Ignoring them is also fine.
+* **D** (Dirty): If set, indicates that a page has been written to since last cleared. This flag is supposed to only apply to page tables, but some emulators will set it on other levels as well. This flag and the accessed flag are provided for being use by the memory management software, the CPU only set it when its value is 0. Otherwise, is up to the operating system's memory manager to decide if it has to be cleared or not. Ignoring them is also fine.
 * **PS** (Page Size): Reserved in the pml4, if set on the PDPR it means address translation stops at this level and is mapping a 1GB page. Check for 1gb page support before using this. More commonly this can be set on the PD entry to stop translation at that level, and map a 2MB page.
 * **PAT** (Page Attribute Table Index) only for the page table: It selects the PAT entry (in combination with the PWT and PCD bits above), refer to the Intel Manual for a more detailed explanation.
 * **G** (Global): If set it indicates that when CR3 is loaded or a task switch occurs that this particular entry should not be ejected. This feature is not architectural, and should be checked for before using.
 * **PK** (Protection Key): A 4-bit value used to control supervisor & user level accesses for a virtual address. If bit 22 (PKE) is set in CR4, the PKRU register will be used to control access rights for user level accesses based on the PK, and if bit 24 (PKS) is set, same will happen but for supervisor level accesses with the PKRS register. **Note**: This value is ignored on older CPUs, which means those bits are marked as available on them. If you want to use the protection key, make sure to check for its existence using CPUID, and of course to set the corresponding bits for it in the CR4 register.
 * **XD**: Also known as NX, the execute disable bit is only available if supported by the CPU (can be checked wit CPUID), otherwise reserved. If supported, and after enabling this feature in EFER (see the intel manual for this), attempting to execute code from a page with this bit set will result in a page fault.
 
-Note about PWT and PCD, the definiton of those bits depends on whether PAT (page attribute tables) are in use or not. For a better understanding of those two bits please refer to the most updated intel documentation (is in the Paging section of the intel Software Developer Manual vol.3)
+Note about PWT and PCD, the definition of those bits depends on whether PAT (page attribute tables) are in use or not. For a better understanding of those two bits please refer to the most updated intel documentation (is in the Paging section of the intel Software Developer Manual vol.3)
 
 ## Address translation
 
@@ -250,10 +250,10 @@ Every table has 512 elements, so we have an address space of: $2^{512}*2^{512}*2
 
 ## Page Fault
 
-A page fault (exception 14, triggers the interrupt of the same number) is raised when address translation fails for any reason. An error code is pushed on to the stack before calling the interrupt handler describing the situation when the fault occured. Note that these bits describe was what was happening, not why the fault occured. If the user bit is set, it does not necessarily mean it was a priviledge violation. The `CR2` register also contains the address that caused the fault.
+A page fault (exception 14, triggers the interrupt of the same number) is raised when address translation fails for any reason. An error code is pushed on to the stack before calling the interrupt handler describing the situation when the fault occurred. Note that these bits describe was what was happening, not why the fault occurred. If the user bit is set, it does not necessarily mean it was a privilege violation. The `CR2` register also contains the address that caused the fault.
 
 The idea of the page fault handler is to look at the error code and faulting address, and do one of several things:
-- If the program is accessing memory that it should have, but hasnt been mapped: map that memory as initially requested.
+- If the program is accessing memory that it should have, but hasn't been mapped: map that memory as initially requested.
 - If the program is attempting to access memory it should not, terminate the program.
 
 The error code has the following structure:
@@ -267,10 +267,10 @@ The meanings of these bits are expanded below:
 
 * Bits 31...4 are reserved.
 * Bit 4: set if the fault was an instruction fetch.
-* Bit 3: set if the attempted translation encuntered a reserved bit being set to 1 (at *some* level in the paging structure).
+* Bit 3: set if the attempted translation encountered a reserved bit being set to 1 (at *some* level in the paging structure).
 * Bit 2: set if the access was a user mode access, otherwise it was supervisor mode.
 * Bit 1: set if the false was caused by a write, otherwise it was a read.
-* Bit 0: set if a protection violation caused the fault, otherwise it means translation failed due to a non present page.
+* Bit 0: set if a protection violation caused the fault, otherwise it means translation failed due to a non-present page.
 
 ## Accessing Page Tables and Physical Memory
 
@@ -280,12 +280,12 @@ One of the problems that we face while enabling _paging_ is of how to access the
 
 There are two ways to achieve it:
 
-* Having all the phyisical memory mapped somewhere in the virtual addressing space (probably in the _Higher Half_, in this case we should be able to retrieve all the tables easily, by just adding a prefix to the physical address of the table.
-* Using a tecnique called _recursion_, where access the tables using special virtual addresses.
+* Having all the physical memory mapped somewhere in the virtual addressing space (probably in the _Higher Half_, in this case we should be able to retrieve all the tables easily, by just adding a prefix to the physical address of the table).
+* Using a technique called _recursion_, where access the tables using special virtual addresses.
 
-To use the recursion the only thing we need to do, is reserve an entry in the _root_ page directory (`PML4` in our case) and make its base address to point to the directory itsef.
+To use the recursion the only thing we need to do, is reserve an entry in the _root_ page directory (`PML4` in our case) and make its base address to point to the directory itself.
 
-A good idea is to pick a number high enough, that will not interfer with other kernel/hardware special addresses. For example let's use the entry `510` for the recurisve item
+A good idea is to pick a number high enough, that it will not interfere with other kernel/hardware special addresses. For example let's use the entry `510` for the recursive item.
 
 Creating the self reference is pretty straightforward, we just need to use the directory physical address as the base address for the entry being created:
 
@@ -301,12 +301,12 @@ Now as we have seen above address translation will split the `virtual address` i
 virt_addr = 0xff7f80005000
 ```
 
-The entries in this address are: 510 for PML4, 510 for PDPR, 0 for PD and 5 for PT (we are using 4k pages for this example).  Now let's see what appens from the point of view of the address translation:
+The entries in this address are: 510 for PML4, 510 for PDPR, 0 for PD and 5 for PT (we are using 4k pages for this example). Now let's see what happens from the point of view of the address translation:
 
 * First the `510th` PML4 entry is loaded, that is the pointer to the PDPR, and in this case its content is PML4 itself.
 * Now it get the next entry from the address, to load the PD, that is again the `510th`, and is again PML4 itself, so it is loaded as PD too.
 * It is time for the third entry the PT, and in this case we have `0`, so it loads the first entry from the Page Directory loaded, that in this case is still PML4, so it loads the PDPR table
-* Finally the PT entry is loaded, that is `5`, and since the current PD loaded for translation is actually a PDPR we are going to get the `5th` item of the page directory.
+* Finally, the PT entry is loaded, that is `5`, and since the current PD loaded for translation is actually a PDPR we are going to get the `5th` item of the page directory.
 * Now the last part of the address is the offset, this can be used then to access the entries of the directory/table loaded.
 
 This means that by carefully using the recursive item from PML4 we can access all the tables.
@@ -315,22 +315,22 @@ Few more examples of address translation:
 
 * PML4: 511 (hex: 1ff) - PDPR: 510 (hex: 1fe) - PD 0 (hex: 0) using 2mb pages translates to: `0xFFFF'FFFF'8000'0000`.
 * Let's assume we mapped PML4 into itself at entry 510,
-    - If we want to access the content of the PML4 page itself, using the recursion we need to build a special address using the entries: _PML4: 510, PDPR: 510, PD: 510, PT: 510_, now keep in mind that the 510th entry of PML4 is PML4 itself, so this means that when the processor loads that entry, it loads PML4 itself instead of PDPR, but now the value for the PDPR entry is still 510, that is still PML4 then, the table loaded is PML4 again, repat this process for PD and PT with page number equals to 510, and we got access to the PML4 table.
-    - Now using a similar approach we can get acces to other tables, for example the following values: _PML4: 510, PDPR:510, PD: 1, PT: 256_, will give access at the Page Directory PD at entry number 256 in PDPR that is contained in the first PML4 entry.
+    - If we want to access the content of the PML4 page itself, using the recursion we need to build a special address using the entries: _PML4: 510, PDPR: 510, PD: 510, PT: 510_, now keep in mind that the 510th entry of PML4 is PML4 itself, so this means that when the processor loads that entry, it loads PML4 itself instead of PDPR, but now the value for the PDPR entry is still 510, that is still PML4 then, the table loaded is PML4 again, repeat this process for PD and PT with page number equals to 510, and we got access to the PML4 table.
+    - Now using a similar approach we can get access to other tables, for example the following values: _PML4: 510, PDPR:510, PD: 1, PT: 256_, will give access at the Page Directory PD at entry number 256 in PDPR that is contained in the first PML4 entry.
 
 This technique makes it easy to access page tables in the current address space, but it falls apart for accessing data in other address spaces. For that purpose, we'll need to either use a different technique or switch to that address space, which can be quite costly.
 
 ### Direct Map
 
-Another technique for modifying page tables is a 'direct map' (similar to an identity map). As we know an identity map is when a page's physical address is the same as its virtual address, and we could describe it as: `paddr = vaddr`. A direct map is sometimes referred to as an _offset map_ because it introduces an offset, which gives us some flexibility. We're using to have a global variable containing the offset for our map called `dmap_base`. Typically we'll set this to some address in the higher half so that the lower half of the address space is completely free for userspace programs. This also makes other parts of the kernel easier later on.
+Another technique for modifying page tables is a 'direct map' (similar to an identity map). As we know an identity map is when a page's physical address is the same as its virtual address, and we could describe it as: `paddr = vaddr`. A direct map is sometimes referred to as an _offset map_ because it introduces an offset, which gives us some flexibility. We're using to have a global variable containing the offset for our map called `dmap_base`. Typically, we'll set this to some address in the higher half so that the lower half of the address space is completely free for userspace programs. This also makes other parts of the kernel easier later on.
 
-How does the direct map actually work though? It's simple enough, we just map all of physical memory at the same virtual address *plus the dmap_base offset*: `paddr = vaddr - dmap_base`. Now in order to access a physical page (from our PMM for example) we just add `dmap_base` to it and we can read and write to it as normal.
+How does the direct map actually work though? It's simple enough, we just map all of physical memory at the same virtual address *plus the dmap_base offset*: `paddr = vaddr - dmap_base`. Now in order to access a physical page (from our PMM for example) we just add `dmap_base` to it, and we can read and write to it as normal.
 
 The direct map does require a one-time setup early in your kernel, as you do need to map all usable physical memory starting at `dmap_base`. This is no more work than creating an identity map though.
 
 What address should you use for the base address of the direct map? Well you can put it at the lowest address in the higher half, which depends on how many levels of page tables you have. For 4 level paging this will `0xffff'8000'0000'0000`.
 
-While recursive paging only requires using a single page table entry at the highest level, a direct map consumes a decent chunk of address space. A direct map is also more flexible as it allows the kernel to access arbitrary parts of physical memory as needed, . Direct mapping is only really possible in 64-bit kernels due to the large address space made available, 32-bit kernels should opt to use recursive mapping to reduce the amount of address space used.
+While recursive paging only requires using a single page table entry at the highest level, a direct map consumes a decent chunk of address space. A direct map is also more flexible as it allows the kernel to access arbitrary parts of physical memory as needed. Direct mapping is only really possible in 64-bit kernels due to the large address space made available, 32-bit kernels should opt to use recursive mapping to reduce the amount of address space used.
 
 The real potential of this technique will unveil when we have multiple address spaces to handle, when the kernel may need to update data in different address spaces (especially the paging data structures), in this case using the direct map it can access any data in any address space, by only knowing its physical address. It will also help when we will start to work on device drivers (out of the scope of this book) where the kernel may need to access the DMA buffers, that are stored by their physical addresses.
 

--- a/04_Memory_Management/05_Heap_Allocation.md
+++ b/04_Memory_Management/05_Heap_Allocation.md
@@ -295,7 +295,7 @@ Now we have a decent and working function that can free previously allocated mem
 * There is a lot of potential waste of space, for example if we are allocating 10 bytes, and the heap has two holes big enough the first is 40 bytes, the second 14, the algorithm will pick the first one free so the bigger one with a waste of 26 bytes. There can be different solution to this issue, but is out of the purpose of this tutorial (and eventually left as an exercise)
 * It can suffer from fragmentation. Basically there can be a lot of small freed areas that the allocator will not be able to use because of their size. A partial solution to this problem is described in the next paragraph.
 
-Another thing worth doing to improve readability of the code by replacing the direct pointer access with a more elegant data structure. This lets us add more fields (as we will in the next paragraph) as needed.
+Another thing worth doing is to improve readability of the code by replacing the direct pointer access with a more elegant data structure. This lets us add more fields (as we will in the next paragraph) as needed.
 
 So far our allocator needs to keep track of just the size of the block returned and its status The data structure for this could look like the following:
 
@@ -451,7 +451,7 @@ After that the allocator can compute the address to return using `(uintptr_t)cur
 Before wrapping up there's a few things worth pointing out about implementing splitting:
 
 * Remember that every node has some overhead, so when splitting we shouldn't have nodes smaller (or equal to) than `sizeof(Heap_Node)`, because otherwise they will never be allocated.
-* It's a good idea to have a minimum size for the memory a chunk can contain, to avoid having a large number of nodes and for easy alignment later on. For example if the minimum_allocatable_size is 0x20 bytes, and we want to allocate 5 bytes, we will still receive a memory block of `0x20` bytes. The program may not know it was returned `0x20` bytes, but that is okay. What exactly value should be used for it is implementation specific, values of `0x10` and `0x20` are popular.
+* It's a good idea to have a minimum size for the memory a chunk can contain, to avoid having a large number of nodes and for easy alignment later on. For example if the `minimum_allocatable_size` is 0x20 bytes, and we want to allocate 5 bytes, we will still receive a memory block of `0x20` bytes. The program may not know it was returned `0x20` bytes, but that is okay. What exactly value should be used for it is implementation specific, values of `0x10` and `0x20` are popular.
 * Always remember that there is the memory footprint of `sizeof(Heap_Node)` bytes while computing sizes that involve multiple nodes. If we decide to include the overhead size in the node's size, remember to also subtract it when checking for suitable nodes.
 
 And that's it!

--- a/04_Memory_Management/README.md
+++ b/04_Memory_Management/README.md
@@ -4,7 +4,7 @@ This part will cover all the topic related on how to build a memory management m
 
 Below the list of chapters: 
 
-* [Overview](01_Overview.md) It introduces the basic concepts of memory management, and provide an high level overview of all the layers that are part of it.
+* [Overview](01_Overview.md) It introduces the basic concepts of memory management, and provide a high level overview of all the layers that are part of it.
 * [Physical Memory Manager](02_Physical_Memory.md) The lowest layer, the physical memory manager, it deals with "real memory".
 * [Paging](03_Paging.md) Paging will provide a separation between a physical memory address and a virtual address. This mean that the kernel we will be able to access much more addresses than the ones available.
 * [Virtual Memory Manager](04_Virtual_Memory_Manager.md) It sits between the heap and the physical memory manager, it is similar to the Physical Memory Manager, but for the virtual space.

--- a/99_Appendices/I_Acknowledgments.md
+++ b/99_Appendices/I_Acknowledgments.md
@@ -19,3 +19,4 @@ In no particular order:
 - @Moldytzu ([https://github.com/Moldytzu](https://github.com/Moldytzu))
 - @AnErrupTion ([https://github.com/AnErrupTion](https://github.com/AnErrupTion))
 - @MRRcode979 ([https://github.com/MRRcode979](https://github.com/MRRcode979))
+- @Hqnnqh ([https://github.com/Hqnnqh](https://github.com/Hqnnqh))


### PR DESCRIPTION
A couple of typo and grammar fixes across the memory management chapter. 