### PR TITLE
Update runners

### DIFF
--- a/.github/workflows/pandoc_workflow.yaml
+++ b/.github/workflows/pandoc_workflow.yaml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     paths-ignore: [ '**/README.md',  '**/FUNDING.yml', '**/sync-gh-pages.yaml' ]
-    branches: [ update_runners ]
+    branches: [ master ]
 
  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/pandoc_workflow.yaml
+++ b/.github/workflows/pandoc_workflow.yaml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # It will run on ubuntu-latest image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/pandoc_workflow.yaml
+++ b/.github/workflows/pandoc_workflow.yaml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     paths-ignore: [ '**/README.md',  '**/FUNDING.yml', '**/sync-gh-pages.yaml' ]
-    branches: [ master ]
+    branches: [ update_runners ]
 
  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,13 +23,7 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
-          sudo apt-get -y install texlive-latex-base texlive texlive-xetex texlive-fonts-recommended librsvg2-2 liblua5.3-0 librsvg2-bin librsvg2-common
-          wget http://launchpadlibrarian.net/620071728/libgmp10_6.2.1+dfsg1-1ubuntu2_amd64.deb
-          wget https://blueprints.launchpad.net/ubuntu/+archive/primary/+files/pandoc_2.17.1.1-1ubuntu2_amd64.deb
-          wget http://launchpadlibrarian.net/621653025/pandoc-data_2.17.1.1-1ubuntu2_all.deb
-          sudo dpkg -i libgmp10_6.2.1+dfsg1-1ubuntu2_amd64.deb
-          sudo dpkg -i pandoc-data_2.17.1.1-1ubuntu2_all.deb
-          sudo dpkg -i pandoc_2.17.1.1-1ubuntu2_amd64.deb
+          sudo apt-get -y install texlive-latex-base texlive texlive-xetex texlive-fonts-recommended librsvg2-2 liblua5.3-0 librsvg2-bin librsvg2-common libgmp10 pandoc pandoc-data
       - name: Run build script
         run: |
           pandoc -v


### PR DESCRIPTION
Apparently now we no longer need the workaround if we use ubuntu-24.04 runner, the below action is running succesfully: 

https://github.com/dreamportdev/Osdev-Notes/actions/runs/11470217335/job/31918967119