### PR TITLE
Typo fixes for Makefile and linker in "Build Process" chapter

### DIFF
--- a/01_Build_Process/03_Gnu_Makefiles.md
+++ b/01_Build_Process/03_Gnu_Makefiles.md
@@ -26,7 +26,7 @@ TARGET = build/kernel.elf
 
 #flags
 CC_FLAGS = -g -ffreestanding
-LD_FLAGS = -T linker_script.lds -ffreestanding -shared
+LD_FLAGS = -T linker_script.lds
 
 #auto populated variables
 OBJS = $(patsubst %.c, build/%.c.o, $(C_SRCS))

--- a/01_Build_Process/03_Gnu_Makefiles.md
+++ b/01_Build_Process/03_Gnu_Makefiles.md
@@ -17,7 +17,7 @@ Below is an example of a basic Makefile.
 CC = x86_64-elf-gcc
 CXX = x86_64-elf-g++
 AS = x86_64-elf-as
-LD = x86_64_elf-ld
+LD = x86_64-elf-ld
 
 #inputs
 C_SRCS = kernel_main.c util.c
@@ -26,11 +26,11 @@ TARGET = build/kernel.elf
 
 #flags
 CC_FLAGS = -g -ffreestanding
-LD_FLAGS = -T linker_script.lds -ffreestanding
+LD_FLAGS = -T linker_script.lds -ffreestanding -shared
 
 #auto populated variables
 OBJS = $(patsubst %.c, build/%.c.o, $(C_SRCS))
-OBJS += $(patsubst %.S, build/%.S.o, %(ASM_SRCS))
+OBJS += $(patsubst %.S, build/%.S.o, $(ASM_SRCS))
 
 .PHONY: all clean
 

--- a/01_Build_Process/04_Linker_Scripts.md
+++ b/01_Build_Process/04_Linker_Scripts.md
@@ -196,7 +196,7 @@ SECTIONS
         /* Then we can map those pages appropriately. */
         TEXT_BEGIN = .;
         *(.text*)
-        TEXT_END = ,;
+        TEXT_END = .;
     } :text
 
     /* a trick to ensure the section next is on the next physical */

--- a/99_Appendices/I_Acknowledgments.md
+++ b/99_Appendices/I_Acknowledgments.md
@@ -22,3 +22,4 @@ In no particular order:
 - @Hqnnqh ([https://github.com/Hqnnqh](https://github.com/Hqnnqh))
 - @malletgaetan ([https://github.com/malletgaetan](https://github.com/malletgaetan))
 - @mrjbom ([https://github.com/mrjbom](https://github.com/mrjbom))
+- @AFellowSpeedrunner ([https://github.com/AFellowSpeedrunner](https://github.com/AFellowSpeedrunner))


### PR DESCRIPTION
I was following these sections and kept having errors. After some experimenting, I found out there were some typos in the code examples of the changed files.

(For example, there was a ',' where there should have been a '.' in the linker script. 

There was also a '%' where there should have been a '$' when calling variables in the Makefile. In the same Makefile, there was also a mistyping of 'x86_64-elf-ld' which had an '_' in between 'x86_64' and 'elf'.

I also fixed an issue that I encountered on my side with the same programs where it wouldn't link without -shared being specified in Makefile.)

I hope this pull request helps.