### PR TITLE
osdev: userspace: switching modes fix wrong order

### DIFF
--- a/06_Userspace/02_Switching_Modes.md
+++ b/06_Userspace/02_Switching_Modes.md
@@ -35,8 +35,8 @@ So if we're going to ring 0 (supervisor), RPL can be left at 0. If going to ring
 This means our selectors for `ss` and `cs` end up looking like this:
 
 ```c
-kernel_ss = 0x08 | 0;
-kernel_cs = 0x10 | 0;
+kernel_cs = 0x08 | 0;
+kernel_ss = 0x10 | 0;
 user_cs   = 0x18 | 3;
 user_ss   = 0x20 | 3;
 ```

--- a/99_Appendices/I_Acknowledgments.md
+++ b/99_Appendices/I_Acknowledgments.md
@@ -23,3 +23,4 @@ In no particular order:
 - @malletgaetan ([https://github.com/malletgaetan](https://github.com/malletgaetan))
 - @mrjbom ([https://github.com/mrjbom](https://github.com/mrjbom))
 - @IAmTheNerdNextDoor ([https://github.com/IAmTheNerdNextDoor](https://github.com/IAmTheNerdNextDoor))
+- @vasilisalmpanis ([https://github.com/vasilisalmpanis](https://github.com/vasilisalmpanis))


### PR DESCRIPTION
according to the description above the code segment has offset 0x8
and the data segment has offset 0x16. Fix wrong ordering.