### PR TITLE
Page Fault Vector Typo

### DIFF
--- a/04_Memory_Management/03_Paging.md
+++ b/04_Memory_Management/03_Paging.md
@@ -85,7 +85,7 @@ There are 3 possible scenarios:
 * 2Mib Pages: in this case we only need 3 page levels.
 * 1Gib Pages: Only 2 levels are needed.
 
-To implement paging, is strongly recommended to have already implemented interrupts too, specifically handling #PF (vector 0xd).
+To implement paging, is strongly recommended to have already implemented interrupts too, specifically handling #PF (vector 0xE).
 
 The 4 levels of page directories/tables are:
 


### PR DESCRIPTION
GP is vector 13 (0xD), while PF is 14 (0xE) per Intel SDM vol 3A. 
https://wiki.osdev.org/Interrupt_Descriptor_Table