### PR TITLE
Fix typo on line 172 of Interrupt Handling section

### DIFF
--- a/02_Architecture/05_InterruptHandling.md
+++ b/02_Architecture/05_InterruptHandling.md
@@ -19,7 +19,7 @@ There will be situations where we don't want to be interrupted, usually in some 
 
 When the interrupt flag is cleared, most interrupts will be *masked*, meaning they will not be served. There is a special case where an interrupt will still be served by the cpu: the *non-maskable interrupt* or NMI. These are extremely rare, and often a result of a critical hardware failure, therefore it's perfectly acceptable to simply have the operating system panic in this case.
 
-*Authors note: Don't let NMIs scare you, we've never run actually run into one on real hardware. You do need to be aware that they exist and can happen at any time, regardless of the interrupt flag.*
+*Authors note: Don't let NMIs scare you, we've never actually run into one on real hardware. You do need to be aware that they exist and can happen at any time, regardless of the interrupt flag.*
 
 ## Setting Up For Handling Interrupts
 

--- a/02_Architecture/05_InterruptHandling.md
+++ b/02_Architecture/05_InterruptHandling.md
@@ -169,7 +169,7 @@ push %rbx
 push %r14
 push %r15
 
-call interrupt_disaptch
+call interrupt_dispatch
 
 pop %r15
 pop %r14

--- a/02_Architecture/05_InterruptHandling.md
+++ b/02_Architecture/05_InterruptHandling.md
@@ -173,7 +173,7 @@ call interrupt_dispatch
 
 pop %r15
 pop %r14
-//push other registers here
+//pop other registers here
 pop %rbx
 pop %rax
 


### PR DESCRIPTION
This should fix the typo on line 172 on the line where it contains,
`call interrupt_disaptch` instead of `call interrupt_dispatch` and fix a misplaced comment.